### PR TITLE
fix: return Only implemented Strategy (ATP) to avoid Error for Export…

### DIFF
--- a/atp-mia-backend/src/main/java/org/qubership/atp/mia/ei/component/ExportStrategiesRegistry.java
+++ b/atp-mia-backend/src/main/java/org/qubership/atp/mia/ei/component/ExportStrategiesRegistry.java
@@ -46,6 +46,6 @@ public class ExportStrategiesRegistry {
         return exportStrategies.stream()
                 .filter(exportStrategy -> format.equals(exportStrategy.getFormat()))
                 .findFirst()
-                .orElseThrow(() -> new MiaExportTypeNotSupportException(format.name()));
+                .orElse(exportStrategies.get(0));
     }
 }


### PR DESCRIPTION
For Export Format other that ATP , Export Process on UI Fails with Error . With this commit , atp-mia would not fail for Export Format Different from ATP.