### PR TITLE
fix: The whole process of Export in Postman format fails because some tools don't support this format

### DIFF
--- a/atp-mia-backend/src/main/java/org/qubership/atp/mia/ei/component/ExportStrategiesRegistry.java
+++ b/atp-mia-backend/src/main/java/org/qubership/atp/mia/ei/component/ExportStrategiesRegistry.java
@@ -46,6 +46,6 @@ public class ExportStrategiesRegistry {
         return exportStrategies.stream()
                 .filter(exportStrategy -> format.equals(exportStrategy.getFormat()))
                 .findFirst()
-                .orElseThrow(() -> new MiaExportTypeNotSupportException(format.name()));
+                .orElse(exportStrategies.get(0));
     }
 }


### PR DESCRIPTION
Some tools support export in Postman format, some others - don't.
A tool throws an exception ("Unknown export format"), sends it to Export Coordinator, and the whole process of export fails due to it.
The fix should be like this:
- Instead of exception, a tool should log it, and do nothing or perform export in default format - it should depend on tool specifics.
<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-mia/commit/ad9576aada0fbc84cebfe57696892aeea283cf03) fix: return Only implemented Strategy (ATP) to avoid Error for Export Format Different from ATP.
[kagw95](https://github.com/Netcracker/qubership-testing-platform-mia/commit/81f3f81772c67c86d1f71773229fe1282294f2dc) Merge pull request #72 from akshaymahajan855/fix_postman_export

fix: return Only implemented Strategy (ATP) to avoid Error for Export…
<!-- end messages -->
