### PR TITLE
fix: fix for NPE when SqlResponse query is null.

### DIFF
--- a/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/execution/ProcessService.java
+++ b/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/execution/ProcessService.java
@@ -406,7 +406,7 @@ public class ProcessService {
                 if (v.getValue().contains(".sql")) {
                     String content =
                             miaContext.evaluate(FileUtils.readFile(miaFileService.getFile(v.getValue()).toPath()));
-                    return content.contains(sqlResponse.getQuery());
+                    return sqlResponse.getQuery() != null && content.contains(sqlResponse.getQuery());
                 } else {
                     return miaContext.evaluate(v.getValue()).equals(sqlResponse.getQuery());
                 }


### PR DESCRIPTION
During SQL response validation, in error scenarios (for example, an invalid SQL file path), SqlResponse is generated without a query, which results in a NullPointerException. This fix prevents the crash and avoids an Internal Server Error