### PR TITLE
fix: handle empty prerequisite reference lists

### DIFF
--- a/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/configuration/ProcessConfigurationService.java
+++ b/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/configuration/ProcessConfigurationService.java
@@ -257,7 +257,25 @@ public class ProcessConfigurationService extends AbstractEntityHistoryService<Pr
                 processConfiguration.getProcessSettings().getCommand().getAtpValues());
         retValue.getProcessSettings().getCommand().setVariablesToExtractFromLog(
                 processConfiguration.getProcessSettings().getCommand().getVariablesToExtractFromLog());
+        normalizePrerequisiteReferFields(retValue);
         return retValue;
+    }
+
+    private void normalizePrerequisiteReferFields(ProcessDto processDto) {
+        if (processDto.getProcessSettings() == null
+                || processDto.getProcessSettings().getPrerequisites() == null) {
+            return;
+        }
+        processDto.getProcessSettings().getPrerequisites().forEach(prerequisite -> {
+            if (prerequisite.getReferToInputName() != null
+                    && prerequisite.getReferToInputName().isEmpty()) {
+                prerequisite.setReferToInputName(null);
+            }
+            if (prerequisite.getReferToCommandValue() != null
+                    && prerequisite.getReferToCommandValue().isEmpty()) {
+                prerequisite.setReferToCommandValue(null);
+            }
+        });
     }
 
     /**

--- a/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/execution/ProcessService.java
+++ b/atp-mia-backend/src/main/java/org/qubership/atp/mia/service/execution/ProcessService.java
@@ -764,16 +764,16 @@ public class ProcessService {
         final List<String> commandValuesToRefer = prerequisite.getReferToCommandValue();
         final List<String> inputNamesToRefer = prerequisite.getReferToInputName();
         boolean toSkip = false;
-        if (commandValuesToRefer != null) {
+        if (commandValuesToRefer != null && !commandValuesToRefer.isEmpty()) {
             if (commandValuesToRefer.stream().anyMatch(commandValue ->
                     commandValue.equalsIgnoreCase(command.getToExecute()))) {
-                if (inputNamesToRefer != null) {
+                if (inputNamesToRefer != null && !inputNamesToRefer.isEmpty()) {
                     toSkip = checkInput(inputNamesToRefer);
                 }
             } else {
                 toSkip = true;
             }
-        } else if (inputNamesToRefer != null) {
+        } else if (inputNamesToRefer != null && !inputNamesToRefer.isEmpty()) {
             toSkip = checkInput(inputNamesToRefer);
         }
         return toSkip;


### PR DESCRIPTION
With OpenAPI Generator version 7.9.0 ,  In prerequisiteDTO,  fields referToInputName and referToCommandValue were initialized as empty Arraylist [] instead of null
Due to this In UI - In prerequisites ,  empty referToInputName , referToCommandValue lists were treated as configured conditions, causing prerequisites to be hidden in the UI and skipped during execution.
This PR convert empty referToInputName and referToCommandValue lists to null in the GET response DTO ,and 
Updates prerequisite execution logic so both null and [] are treated as “no condition.”

<!-- start messages -->
### Commit messages:
[akshaymahajan855](https://github.com/Netcracker/qubership-testing-platform-mia/commit/0cb4d2867ed1fe56ee82781642e500f3eb060fda) fix: handle empty prerequisite reference lists
<!-- end messages -->
